### PR TITLE
Add support for using other shells with the -i/--shell-interpreter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ You can also get clever with `map -e`:
 map -f hosts -e 'ssh $1 df -h' | awk '{print $1, $(NF-1)}'
 ```
 Outputs the `<host, disk usage>` pairs
+
+By default, `map` uses the bash shell (at `/bin/bash`) for invoking workers. To change the shell, pass a different `-i`/`--shell-interpreter` option. All shells that implement a `-c` option are supported by `map`, this list has been tested and known to work:
+
+- `sh`
+- `ksh`
+- `bash`
+- `dash`
+- `zsh`

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func Run(flags *MapFlags, args []string) error {
 	shell_basename := flags.ShellInterpreter
 	idx := strings.LastIndex(flags.ShellInterpreter, "/")
 	if idx > 0 {
-		shell_basename = flags.ShellInterpreter[idx:]
+		shell_basename = flags.ShellInterpreter[idx+1:]
 	}
 	switch shell_basename {
 	case "ksh", "ksh93", "bash", "dash", "zsh", "sh":


### PR DESCRIPTION
This also adds a check that the shell given by the user is "supported", that is, tested and known to work with `-c`. I found that the majority of commonly used shells support the `-c` argument, so I'm picking off the low-hanging fruit first with this PR. I'm planning support for `fish` next, but it'll require prepending commands like `set -x 1 "first line";` to the command being interpreted.